### PR TITLE
fix(server): rolling 30-day window + force-refresh for nearby birds

### DIFF
--- a/packages/server/src/schema/resolvers.test.ts
+++ b/packages/server/src/schema/resolvers.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock artdatabanken module before importing resolvers
+vi.mock("../services/artdatabanken.js", () => ({
+  getAreaDistribution: vi.fn(),
+  calculateSpeciesRarity: vi.fn(),
+  getWikipediaSummary: vi.fn(),
+  getWikimediaImage: vi.fn().mockResolvedValue(null),
+  clearDistributionCache: vi.fn(),
+}));
+
+// Mock Prisma
+vi.mock("@prisma/client", () => {
+  function PrismaClient() {
+    return {
+      species: { findMany: vi.fn(), findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
+      sighting: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(), count: vi.fn(), groupBy: vi.fn() },
+      user: { findUnique: vi.fn(), create: vi.fn() },
+    };
+  }
+  return { PrismaClient };
+});
+
+const FAKE_DISTRIBUTION = {
+  entries: [
+    { taxonId: 1, scientificName: "Parus major", vernacularName: "talgoxe", observationCount: 50 },
+    { taxonId: 2, scientificName: "Cyanistes caeruleus", vernacularName: "blåmes", observationCount: 40 },
+    { taxonId: 3, scientificName: "Fringilla coelebs", vernacularName: "bofink", observationCount: 30 },
+    { taxonId: 4, scientificName: "Erithacus rubecula", vernacularName: "rödhake", observationCount: 5 },
+    { taxonId: 5, scientificName: "Turdus merula", vernacularName: "koltrast", observationCount: 4 },
+    { taxonId: 6, scientificName: "Sitta europaea", vernacularName: "nötväcka", observationCount: 3 },
+  ],
+  totalSpecies: 6,
+  fetchedAt: Date.now(),
+};
+
+const COORDS = { latitude: 59.3, longitude: 18.0 };
+
+describe("nearbyBirds resolver — force flag", () => {
+  let resolvers: typeof import("./resolvers.js")["resolvers"];
+  let getAreaDistribution: ReturnType<typeof vi.fn>;
+  let clearDistributionCache: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const artdatabanken = await import("../services/artdatabanken.js");
+    getAreaDistribution = artdatabanken.getAreaDistribution as ReturnType<typeof vi.fn>;
+    clearDistributionCache = artdatabanken.clearDistributionCache as ReturnType<typeof vi.fn>;
+    getAreaDistribution.mockResolvedValue(FAKE_DISTRIBUTION);
+    clearDistributionCache.mockImplementation(() => {});
+
+    const mod = await import("./resolvers.js");
+    resolvers = mod.resolvers;
+  });
+
+  it("returns cached result without calling getAreaDistribution on second call (no force)", async () => {
+    // Warm the cache
+    await resolvers.Query.nearbyBirds(undefined, COORDS);
+    getAreaDistribution.mockClear();
+
+    // Second call without force — should use cache
+    await resolvers.Query.nearbyBirds(undefined, COORDS);
+    expect(getAreaDistribution).not.toHaveBeenCalled();
+  });
+
+  it("calls getAreaDistribution when force: true even with a populated cache", async () => {
+    // Warm the cache
+    await resolvers.Query.nearbyBirds(undefined, COORDS);
+    getAreaDistribution.mockClear();
+
+    // Call with force: true — must bypass cache
+    await resolvers.Query.nearbyBirds(undefined, { ...COORDS, force: true });
+    expect(getAreaDistribution).toHaveBeenCalledOnce();
+  });
+
+  it("calls clearDistributionCache before getAreaDistribution when force: true", async () => {
+    const callOrder: string[] = [];
+    clearDistributionCache.mockImplementation(() => { callOrder.push("clear"); });
+    getAreaDistribution.mockImplementation(async () => { callOrder.push("fetch"); return FAKE_DISTRIBUTION; });
+
+    await resolvers.Query.nearbyBirds(undefined, { ...COORDS, force: true });
+
+    expect(callOrder).toEqual(["clear", "fetch"]);
+  });
+});

--- a/packages/server/src/schema/resolvers.ts
+++ b/packages/server/src/schema/resolvers.ts
@@ -7,6 +7,7 @@ import {
   getWikipediaSummary,
   getAreaDistribution,
   calculateSpeciesRarity,
+  clearDistributionCache,
 } from "../services/artdatabanken.js";
 
 const prisma = new PrismaClient();
@@ -161,10 +162,14 @@ export const resolvers = {
 
     nearbyBirds: async (
       _: unknown,
-      { latitude, longitude }: { latitude: number; longitude: number },
+      { latitude, longitude, force }: { latitude: number; longitude: number; force?: boolean },
     ) => {
-      // Check cache first (24h per ~22km grid cell)
+      // Check cache first (24h per ~22km grid cell), unless force-refresh requested
       const cacheKey = `nearby_${Math.round(latitude * 5)}_${Math.round(longitude * 5)}`;
+      if (force) {
+        nearbyBirdsCache.delete(cacheKey);
+        clearDistributionCache(latitude, longitude);
+      }
       const cached = nearbyBirdsCache.get(cacheKey);
       if (cached && Date.now() - cached.fetchedAt < NEARBY_BIRDS_TTL) {
         return cached.result;

--- a/packages/server/src/schema/typeDefs.ts
+++ b/packages/server/src/schema/typeDefs.ts
@@ -83,7 +83,7 @@ export const typeDefs = gql`
     mySightings: [Sighting!]!
     mySightingsBySpecies(speciesId: ID!): [Sighting!]!
     myLifeList: [LifeListEntry!]!
-    nearbyBirds(latitude: Float!, longitude: Float!): NearbyBirdsResult!
+    nearbyBirds(latitude: Float!, longitude: Float!, force: Boolean): NearbyBirdsResult!
     speciesByScientificName(scientificName: String!, vernacularName: String): Species
     myStats: UserStats!
     speciesRarity(scientificName: String!, latitude: Float!, longitude: Float!): SpeciesRarity!

--- a/packages/server/src/services/artdatabanken.test.ts
+++ b/packages/server/src/services/artdatabanken.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// We test the exported functions that construct date ranges.
+// fetch is mocked to capture the request body so we can assert on the dates sent.
+
+const FAKE_NOW = new Date("2026-04-06T12:00:00Z").getTime();
+const FAKE_NOW_DATE = new Date(FAKE_NOW);
+const ROLLING_START = new Date(FAKE_NOW - 30 * 24 * 60 * 60 * 1000);
+const ROLLING_START_STR = ROLLING_START.toISOString().split("T")[0]; // "2026-03-07"
+const TODAY_STR = FAKE_NOW_DATE.toISOString().split("T")[0]; // "2026-04-06"
+
+function makeFetchOk(body: object) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => body,
+  });
+}
+
+describe("getTopBirdTaxa()", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(FAKE_NOW);
+    process.env.ARTDATABANKEN_API_KEY = "test-key";
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("uses a rolling 30-day window, not the calendar month", async () => {
+    const mockFetch = makeFetchOk({ totalCount: 0, records: [] });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { getTopBirdTaxa } = await import("./artdatabanken.js");
+    await getTopBirdTaxa(59.3, 18.0);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.date.startDate).toBe(ROLLING_START_STR);
+    expect(body.date.endDate).toBe(TODAY_STR);
+  });
+});
+
+describe("getAllReportCounts()", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(FAKE_NOW);
+    process.env.ARTDATABANKEN_API_KEY = "test-key";
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("uses a rolling 30-day window, not the calendar month", async () => {
+    // getAllReportCounts is not exported — test via getAreaDistribution which calls it.
+    // Instead, we expose it indirectly by intercepting fetch and checking the Search body.
+    const mockFetch = vi.fn()
+      // First call: TaxonAggregation (from getTopBirdTaxa via fetchAreaDistribution)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ totalCount: 0, records: [] }) })
+      // Second call: Search pagination (from getAllReportCounts)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ totalCount: 0, records: [] }) });
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    // Import fresh to avoid module cache contamination
+    const { getAreaDistribution } = await import("./artdatabanken.js");
+    await getAreaDistribution(59.3, 18.0).catch(() => {});
+
+    // The second fetch call is getAllReportCounts's Search request
+    const searchCall = mockFetch.mock.calls.find((call) =>
+      (call[0] as string).includes("/Search"),
+    );
+    expect(searchCall).toBeDefined();
+    const body = JSON.parse(searchCall![1].body);
+    expect(body.date.startDate).toBe(ROLLING_START_STR);
+    expect(body.date.endDate).toBe(TODAY_STR);
+  });
+});
+
+describe("getDistributionCacheKey()", () => {
+  it("produces different keys on day 1 vs day 15 of the same month", async () => {
+    const { getDistributionCacheKey } = await import("./artdatabanken.js");
+
+    const day1 = new Date("2026-04-01T12:00:00Z");
+    const day15 = new Date("2026-04-15T12:00:00Z");
+
+    const key1 = getDistributionCacheKey(59.3, 18.0, day1);
+    const key15 = getDistributionCacheKey(59.3, 18.0, day15);
+
+    expect(key1).not.toBe(key15);
+  });
+});

--- a/packages/server/src/services/artdatabanken.ts
+++ b/packages/server/src/services/artdatabanken.ts
@@ -47,9 +47,18 @@ const distributionCache = new Map<string, AreaDistribution>();
 const inflightRequests = new Map<string, Promise<AreaDistribution>>();
 const CACHE_TTL = 2 * 60 * 60 * 1000; // 2 hours
 
-function getDistributionCacheKey(lat: number, lng: number, date: Date): string {
-  // Round to ~22km grid cells (0.2°) so nearby coordinates share cache
-  return `${Math.round(lat * 5)}_${Math.round(lng * 5)}_${date.getFullYear()}-${date.getMonth()}`;
+export function getDistributionCacheKey(lat: number, lng: number, date: Date): string {
+  // Round to ~22km grid cells (0.2°) so nearby coordinates share cache.
+  // Include rolling start date so the key advances daily as the window moves.
+  const rollingStart = new Date(date.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const startStr = rollingStart.toISOString().split("T")[0];
+  return `${Math.round(lat * 5)}_${Math.round(lng * 5)}_${startStr}`;
+}
+
+export function clearDistributionCache(lat: number, lng: number): void {
+  const key = getDistributionCacheKey(lat, lng, new Date());
+  distributionCache.delete(key);
+  inflightRequests.delete(key);
 }
 
 // Persistent in-memory cache for taxonId → name mappings (never expires — names don't change)
@@ -67,12 +76,10 @@ export async function getTopBirdTaxa(
   take = 20,
   forDate: Date = new Date(),
 ): Promise<TaxonAggregationRecord[]> {
-  const startDate = new Date(forDate.getFullYear(), forDate.getMonth(), 1)
+  const startDate = new Date(forDate.getTime() - 30 * 24 * 60 * 60 * 1000)
     .toISOString()
     .split("T")[0];
-  const endDate = new Date(forDate.getFullYear(), forDate.getMonth() + 1, 0)
-    .toISOString()
-    .split("T")[0];
+  const endDate = forDate.toISOString().split("T")[0];
 
   const res = await fetch(
     `${SOS_BASE_URL}/Observations/TaxonAggregation?skip=0&take=${take}`,
@@ -112,12 +119,10 @@ async function getAllReportCounts(
   longitude: number,
   forDate: Date = new Date(),
 ): Promise<Map<number, number>> {
-  const startDate = new Date(forDate.getFullYear(), forDate.getMonth(), 1)
+  const startDate = new Date(forDate.getTime() - 30 * 24 * 60 * 60 * 1000)
     .toISOString()
     .split("T")[0];
-  const endDate = new Date(forDate.getFullYear(), forDate.getMonth() + 1, 0)
-    .toISOString()
-    .split("T")[0];
+  const endDate = forDate.toISOString().split("T")[0];
 
   const counts = new Map<number, number>();
   const PAGE_SIZE = 1000;


### PR DESCRIPTION
## Summary

Fixes unreliable nearby bird classifications in early days of a calendar month by switching from a calendar-month date range to a rolling 30-day window, and adds cache-busting via `force: Boolean` on the `nearbyBirds` query.

## Changes

- `artdatabanken.ts`: `getTopBirdTaxa()` and `getAllReportCounts()` now use `[today−30d, today]` instead of `[first-of-month, last-of-month]`
- `artdatabanken.ts`: `getDistributionCacheKey()` now includes the rolling start date (`yyyy-mm-dd`) so the cache key advances daily; exported for testability
- `artdatabanken.ts`: new `clearDistributionCache(lat, lng)` export used by the resolver
- `typeDefs.ts`: `nearbyBirds` query accepts optional `force: Boolean` arg
- `resolvers.ts`: when `force: true`, clears both the 24h `nearbyBirdsCache` and the 2h `distributionCache` entry before fetching

## Tests

- Vitest `artdatabanken.test.ts`: asserts rolling 30-day `startDate`/`endDate` in API calls; asserts cache key differs on day 1 vs day 15 of same month
- Vitest `resolvers.test.ts`: asserts cache is used on repeat calls without force; asserts `getAreaDistribution` is called when `force: true`; asserts `clearDistributionCache` is called before fetch
- Playwright: none required

Closes #11