### PR TITLE
chore(deploy): add manual deploy script for TrueNAS host

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,5 +31,5 @@ Each phase runs fresh. Manual checkpoint between every phase. See `docs/guides/a
 - Host: TrueNAS SCALE, static IP `192.168.0.10`, user `henrik`
 - Path: `/var/www/birdlog`
 - SSH: password-based (no key auth — TrueNAS home dir restrictions)
-- Auto-deploy: cron checks for new commits every 5 min
+- Manual deploy: SSH to host, `cd /var/www/birdlog && ./scripts/deploy.sh`
 - SSL: wildcard cert via Nginx Proxy Manager

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -77,4 +77,6 @@ Browser → React SPA → Apollo Client (GraphQL) → Express/Apollo Server → 
 - Host: TrueNAS SCALE at `192.168.0.10`
 - Path: `/var/www/birdlog`
 - SSL: wildcard cert via Nginx Proxy Manager
-- Auto-deploy: cron polling for new commits every 5 min
+- Manual deploy: `ssh henrik@192.168.0.10`, then `cd /var/www/birdlog && ./scripts/deploy.sh`
+  (script fetches `main`, rebuilds the app image, recreates the container; migrations
+  apply themselves on container start)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Manual deploy for Birdlog on the TrueNAS host.
+#
+# Usage (from /var/www/birdlog on the host):
+#   ./scripts/deploy.sh           # deploys current `main`
+#   ./scripts/deploy.sh --no-pull # skips git pull (useful for re-deploying current HEAD)
+#
+# Migrations apply automatically when the new container starts
+# (see Dockerfile CMD). One-off jobs like `backfill:taxonomy`
+# stay manual — run them via `docker compose exec app ...`
+# after this script finishes (see docs/runbooks/).
+
+set -euo pipefail
+
+REPO_DIR="/var/www/birdlog"
+COMPOSE_FILE="docker-compose.prod.yml"
+APP_SERVICE="app"
+BRANCH="main"
+
+SKIP_PULL=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-pull) SKIP_PULL=1 ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$REPO_DIR"
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$current_branch" != "$BRANCH" ]]; then
+  echo "refusing to deploy: on branch '$current_branch', expected '$BRANCH'" >&2
+  exit 1
+fi
+
+before_sha=$(git rev-parse --short HEAD)
+
+if [[ "$SKIP_PULL" -eq 0 ]]; then
+  echo "==> fetching origin"
+  git fetch --prune origin
+
+  echo "==> fast-forwarding $BRANCH"
+  git pull --ff-only origin "$BRANCH"
+fi
+
+after_sha=$(git rev-parse --short HEAD)
+
+if [[ "$before_sha" == "$after_sha" && "$SKIP_PULL" -eq 0 ]]; then
+  echo "==> already at $after_sha — nothing to deploy"
+  echo "    (re-run with --no-pull to force a rebuild)"
+  exit 0
+fi
+
+echo "==> deploying $before_sha -> $after_sha"
+git --no-pager log --oneline "$before_sha..$after_sha" || true
+
+echo "==> building $APP_SERVICE image"
+docker compose -f "$COMPOSE_FILE" build "$APP_SERVICE"
+
+echo "==> recreating containers"
+docker compose -f "$COMPOSE_FILE" up -d
+
+echo "==> waiting for app container to settle (10s)"
+sleep 10
+docker compose -f "$COMPOSE_FILE" ps
+
+echo "==> tail of app logs (last 30 lines)"
+docker compose -f "$COMPOSE_FILE" logs --tail=30 "$APP_SERVICE"
+
+echo
+echo "==> deployed $(git rev-parse --short HEAD) ($(git log -1 --format='%s'))"


### PR DESCRIPTION
The cron-based auto-deploy on the TrueNAS host stopped working and has been removed. This replaces it with a checked-in deploy script.

## Summary

- New `scripts/deploy.sh`:
  - Refuses to run from a non-`main` branch (safety guard)
  - Fetches `origin`, fast-forwards `main`, shows the SHA range being deployed
  - Rebuilds the `app` image and recreates containers via `docker-compose.prod.yml`
  - Tails the last 30 app log lines after deploy
  - `--no-pull` flag to force a rebuild of current HEAD
- Updates `CLAUDE.md` and `docs/architecture/system-overview.md` — replaces the "auto-deploy via cron" lines with the manual deploy command.

Migrations apply themselves when the new container starts (`CMD npx prisma migrate deploy && node ...` in `Dockerfile`). One-off jobs like `backfill:taxonomy` remain manual — see `docs/runbooks/`.

## Deploy flow after merge

```bash
ssh henrik@192.168.0.10
cd /var/www/birdlog
git pull --ff-only         # pull this PR once merged
./scripts/deploy.sh        # all future deploys are just this
```

## Test plan

- [x] `bash -n scripts/deploy.sh` — syntax-clean
- [x] `./scripts/deploy.sh --help` renders usage
- [ ] First real run on TrueNAS host after merge — verify it deploys cleanly and the app is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)