### PR TITLE
chore(deploy): fix deploy script, backfill env, and runbook to match prod reality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 DATABASE_URL="postgresql://birdlog:birdlog@localhost:5432/birdlog?schema=public"
 JWT_SECRET="change-this-to-a-random-secret"
 PORT=4000
+
+# Where Postgres stores its data when running via docker compose.
+# Unset → Docker-managed named volume `birdlog-data` (dev default).
+# Set to an absolute path for a bind mount (prod uses /mnt/Data/AppData/Birdlog/postgres-data).
+# POSTGRES_DATA=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@ services:
       POSTGRES_PASSWORD: birdlog2026
       POSTGRES_DB: birdlog
     volumes:
-      - birdlog-data:/var/lib/postgresql/data
+      # POSTGRES_DATA controls where Postgres stores data.
+      # Unset (default) → uses the named volume `birdlog-data` below.
+      # Absolute path → bind mount (used in prod, e.g. /mnt/Data/AppData/Birdlog/postgres-data).
+      - ${POSTGRES_DATA:-birdlog-data}:/var/lib/postgresql/data
 
   app:
     image: birdlog-app

--- a/docs/runbooks/fagelbok-production-rollout.md
+++ b/docs/runbooks/fagelbok-production-rollout.md
@@ -1,93 +1,112 @@
 # Fågelbok — Production Rollout
 
-One-time steps to make the Fågelbok (#17 / PR #18) feature usable in production.
-The feature is schema-additive and the app starts cleanly with empty taxonomy columns
-— the guidebook page just shows "Inga ordningar har registrerats än." until the
-backfill has run.
+Steps to ship the Fågelbok (#17) feature to production. The migration is
+schema-additive and the app boots cleanly with empty taxonomy columns —
+the guidebook page just shows "Inga ordningar har registrerats än."
+until the backfill has run.
+
+> **Note (2026-05-25):** this runbook was rewritten after the real rollout.
+> The original version assumed `docker-compose.prod.yml`, no `sudo`, and a
+> backfill npm script that worked inside Docker. None of that matched the
+> actual host, which surfaced three repo bugs (`scripts/deploy.sh`, the
+> `backfill:taxonomy` npm script, and the `docker-compose.yml` bind-mount
+> handling). All three are fixed in the follow-up PR that lands this update.
 
 ## Prerequisites
 
-- PR #18 merged to `main` and deployed to prod (auto-deploys every 5 min via cron — see root `CLAUDE.md`)
-- `ARTDATABANKEN_API_KEY` present in the server's production `.env` (same key used by the rest of the app)
-- SSH access to the TrueNAS host: `henrik@192.168.0.10`, app path `/var/www/birdlog`
+- Code merged to `main` and pulled onto the host: `henrik@192.168.0.10:/var/www/birdlog`
+- Host `.env` (at repo root) contains `POSTGRES_DATA=/mnt/Data/AppData/Birdlog/postgres-data`
+- `packages/server/.env` contains `JWT_SECRET`, `OPENAI_API_KEY`, `ARTDATABANKEN_API_KEY`
+- `henrik` has `sudo` for `docker` (TrueNAS SCALE — not in the docker group)
 
-## Step 1 — Apply the Prisma migration
+## Step 1 — Deploy the code
 
-Adds three columns (`order`, `orderScientific`, `familyScientific`) and two indexes
-to the `Species` table. Additive and non-destructive.
+The deploy script rebuilds the app image and recreates the app container.
+Migrations apply on container start (Dockerfile `CMD`).
 
 ```bash
 ssh henrik@192.168.0.10
 cd /var/www/birdlog
-npx prisma migrate deploy --schema=packages/server/prisma/schema.prisma
+./scripts/deploy.sh
 ```
 
-Expected output ends with either "No pending migrations to apply." (already applied)
-or "Applying migration `20260422092129_add_species_taxonomy`".
+Watch the tail for `Applying migration ... add_species_taxonomy` and
+`BirdLog server running at http://localhost:4000/graphql`.
 
 ## Step 2 — Run the taxonomy backfill
 
-Walks every Species row and fills `order` / `orderScientific` / `familyScientific` by
-pulling taxonomy from Artdatabanken. Idempotent — re-runs are safe and only touch
-rows where `orderScientific IS NULL` (use `--force` to re-resolve every row).
+Fills `order` / `orderScientific` / `familyScientific` on every `Species`
+row by pulling taxonomy from Artdatabanken. Idempotent — re-runs touch
+only rows where `orderScientific IS NULL`. Pass `--force` to re-resolve
+every row.
 
 ```bash
-# from /var/www/birdlog on the prod host
-npm run backfill:taxonomy --workspace=packages/server
+sudo docker compose exec app npm run backfill:taxonomy --workspace=packages/server
 ```
 
 What it does:
 
-1. `/Observations/TaxonAggregation` — lists ~1,300 bird taxonIds observed in Sweden (one call).
-2. `/Observations/Search` with `fieldSet: "All"` — chunks of 50 taxonIds, ~30 calls, builds a `scientificName → {family, order}` map. 429s and timeouts retry with exponential backoff; any id missing from a chunk response gets a single-id second pass.
-3. Walks `Species` rows and writes taxonomy (case-insensitive name match; seed has mixed casing).
+1. `POST /Observations/TaxonAggregation` (Aves + underlying taxa) — lists
+   ~1,300 bird taxonIds observed in Sweden in one call.
+2. `POST /Observations/Search` with `fieldSet: "All"` — chunks of 50
+   taxonIds (~30 calls), builds a `scientificName → {family, order}` map.
+   429s and timeouts retry with exponential backoff; any id missing from
+   a chunk response gets a single-id second pass.
+3. Walks `Species` rows and writes taxonomy (case-insensitive name match).
 
 Runtime: ~5–10 min depending on Artdatabanken load.
 
 ## Step 3 — Verify
 
-Expected final line from the backfill:
+Expected final line:
 
 ```
-[backfill] done — resolved 259, skipped 4, 0 without Swedish order name
+[backfill] done — resolved 258, skipped 4, 0 without Swedish order name
 ```
 
-- **259/263 species resolved** (≥90 % is the spec's floor; we're at 98.5 %)
-- **4 skipped** are IOC-vs-Dyntaxa naming drift — not a backfill bug:
-  - `Acanthis hornemanni` (Dyntaxa has it as subspecies `Acanthis flammea hornemanni`)
+- **258/262 species resolved** in prod (98.5 %, well above the spec's 90 % floor).
+- **4 skipped** — IOC-vs-Dyntaxa naming drift, not a backfill bug:
+  - `Acanthis hornemanni` (Dyntaxa: subspecies `Acanthis flammea hornemanni`)
   - `Corvus cornix` (Dyntaxa: `Corvus corone cornix`)
   - `Accipiter gentilis` (renamed in Dyntaxa)
   - `Charadrius dubius` (renamed in Dyntaxa)
 
-These four show up in the guidebook once their seed `scientificName` is aligned to Dyntaxa — handle as a separate follow-up, not a rollout blocker.
+Surface these by aligning their seed `scientificName` to Dyntaxa in a
+follow-up — not a rollout blocker.
 
-Quick DB sanity check from the prod host:
+DB sanity check:
 
 ```bash
-npx prisma studio --schema=packages/server/prisma/schema.prisma
+sudo docker compose exec db psql -U birdlog -d birdlog -c \
+  'SELECT COUNT(*) AS total, COUNT("orderScientific") AS with_order, COUNT(DISTINCT "orderScientific") AS distinct_orders FROM "Species";'
 ```
 
-or via `psql` / the app's Prisma Client:
-
-```sql
-SELECT COUNT(*)                            AS total,
-       COUNT("orderScientific")            AS with_order,
-       COUNT(DISTINCT "orderScientific")   AS distinct_orders
-FROM "Species";
--- expected: total=263, with_order=259, distinct_orders=20
-```
+Expected on prod: `total=262, with_order=258, distinct_orders=20`.
 
 ## Step 4 — Smoke test
 
 Open the deployed app, tap the Fågelbok tab, confirm:
 
 - 20 orders render in the list (alphabetical, Swedish names).
-- Drill into an order → family → species and the species row links to `/bird/:scientificName`.
-- Search `tal` → matches `Talgoxe` (Great Tit); accent variants work.
+- Drill into an order → family → species and the species row links to
+  `/bird/:scientificName`.
+- Search `tal` → matches `Talgoxe`; accent variants work.
 
 ## If something goes wrong
 
-- **`HTTP 429` during backfill** — retries automatically up to 5 times with exponential backoff. If it still fails, wait 10 min and re-run; the backfill picks up only unfilled rows.
-- **Network timeouts on a specific taxonId** — the single-id fallback pass is fault-tolerant per id; the run reports skipped ids and keeps going.
-- **`HTTP 401`** — `ARTDATABANKEN_API_KEY` is missing or invalid in prod `.env`.
-- **Backfill completes but guidebook is still empty** — check `Species.orderScientific` directly in the DB; if every row is `NULL`, the backfill never wrote. Re-run with `--force` and watch the log for errors.
+- **`HTTP 429` during backfill** — retries automatically up to 5 times
+  with exponential backoff. If it still fails, wait 10 min and re-run;
+  the backfill picks up only unfilled rows.
+- **Network timeouts on a specific taxonId** — the single-id fallback
+  pass is fault-tolerant per id; the run reports skipped ids and keeps
+  going.
+- **`HTTP 401`** — `ARTDATABANKEN_API_KEY` is missing or invalid in
+  `packages/server/.env`.
+- **Backfill completes but guidebook is still empty** — check
+  `Species.orderScientific` directly in the DB; if every row is `NULL`,
+  the backfill never wrote. Re-run with `--force` and watch the log for
+  errors.
+- **`env file ... packages/server/.env not found`** during `compose up`
+  — the secrets file isn't on the host. Extract from the running app
+  container's env (see follow-up PR description) or restore from a
+  backup before re-running the deploy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1297,6 +1297,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1313,6 +1314,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1329,6 +1331,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1345,6 +1348,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1361,6 +1365,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1377,6 +1382,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1393,6 +1399,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1409,6 +1416,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1425,6 +1433,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1441,6 +1450,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1457,6 +1467,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1473,6 +1484,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1489,6 +1501,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1505,6 +1518,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1521,6 +1535,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1537,6 +1552,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1553,6 +1569,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1569,6 +1586,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1585,6 +1603,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1601,6 +1620,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1617,6 +1637,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1633,6 +1654,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1649,6 +1671,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1665,6 +1688,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1681,6 +1705,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1697,6 +1722,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3313,9 +3339,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3328,9 +3351,6 @@
       "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3345,9 +3365,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3360,9 +3377,6 @@
       "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3377,9 +3391,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3392,9 +3403,6 @@
       "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3409,9 +3417,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3424,9 +3429,6 @@
       "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3441,9 +3443,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3456,9 +3455,6 @@
       "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3473,9 +3469,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3489,9 +3482,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3504,9 +3494,6 @@
       "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3742,9 +3729,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3760,9 +3744,6 @@
       "integrity": "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3780,9 +3761,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3798,9 +3776,6 @@
       "integrity": "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8209,9 +8184,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8231,9 +8203,6 @@
       "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -8255,9 +8224,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8277,9 +8243,6 @@
       "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12311,6 +12274,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/morgan": "^1.9.10",
         "@types/node": "^22.0.0",
+        "dotenv": "^16.4.5",
         "prisma": "^6.2.0",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
     "db:migrate": "prisma migrate dev",
     "db:seed": "tsx prisma/seed.ts",
     "db:studio": "prisma studio",
-    "backfill:taxonomy": "tsx --env-file=.env prisma/backfill-taxonomy.ts"
+    "backfill:taxonomy": "tsx prisma/backfill-taxonomy.ts"
   },
   "dependencies": {
     "@apollo/server": "^4.11.0",
@@ -37,6 +37,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/morgan": "^1.9.10",
     "@types/node": "^22.0.0",
+    "dotenv": "^16.4.5",
     "prisma": "^6.2.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"

--- a/packages/server/prisma/backfill-taxonomy.ts
+++ b/packages/server/prisma/backfill-taxonomy.ts
@@ -1,3 +1,6 @@
+// Load .env from cwd when present (local runs); no-ops inside the prod
+// container where env vars come from Docker's env_file.
+import "dotenv/config";
 import { PrismaClient } from "@prisma/client";
 import {
   listAllBirdTaxonIds,

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,17 +4,21 @@
 #
 # Usage (from /var/www/birdlog on the host):
 #   ./scripts/deploy.sh           # deploys current `main`
-#   ./scripts/deploy.sh --no-pull # skips git pull (useful for re-deploying current HEAD)
+#   ./scripts/deploy.sh --no-pull # skips git pull (re-deploys current HEAD)
 #
 # Migrations apply automatically when the new container starts
 # (see Dockerfile CMD). One-off jobs like `backfill:taxonomy`
-# stay manual — run them via `docker compose exec app ...`
-# after this script finishes (see docs/runbooks/).
+# stay manual — run them via `sudo docker compose exec ...` after
+# this script finishes (see docs/runbooks/).
+#
+# Requires sudo for docker — the `henrik` user is not in the docker group
+# on TrueNAS SCALE.
+# Requires POSTGRES_DATA in the host's root .env (bind-mount path).
 
 set -euo pipefail
 
 REPO_DIR="/var/www/birdlog"
-COMPOSE_FILE="docker-compose.prod.yml"
+APP_IMAGE="birdlog-app"
 APP_SERVICE="app"
 BRANCH="main"
 
@@ -23,7 +27,7 @@ for arg in "$@"; do
   case "$arg" in
     --no-pull) SKIP_PULL=1 ;;
     -h|--help)
-      sed -n '2,12p' "$0"
+      sed -n '2,14p' "$0"
       exit 0
       ;;
     *)
@@ -38,6 +42,12 @@ cd "$REPO_DIR"
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$current_branch" != "$BRANCH" ]]; then
   echo "refusing to deploy: on branch '$current_branch', expected '$BRANCH'" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "refusing to deploy: working tree is dirty. Resolve before deploying:" >&2
+  git status --short >&2
   exit 1
 fi
 
@@ -62,18 +72,18 @@ fi
 echo "==> deploying $before_sha -> $after_sha"
 git --no-pager log --oneline "$before_sha..$after_sha" || true
 
-echo "==> building $APP_SERVICE image"
-docker compose -f "$COMPOSE_FILE" build "$APP_SERVICE"
+echo "==> building $APP_IMAGE image"
+sudo docker build -t "$APP_IMAGE" .
 
-echo "==> recreating containers"
-docker compose -f "$COMPOSE_FILE" up -d
+echo "==> recreating $APP_SERVICE container (db left alone)"
+sudo docker compose up -d --force-recreate "$APP_SERVICE"
 
 echo "==> waiting for app container to settle (10s)"
 sleep 10
-docker compose -f "$COMPOSE_FILE" ps
+sudo docker compose ps
 
 echo "==> tail of app logs (last 30 lines)"
-docker compose -f "$COMPOSE_FILE" logs --tail=30 "$APP_SERVICE"
+sudo docker compose logs --tail=30 "$APP_SERVICE"
 
 echo
 echo "==> deployed $(git rev-parse --short HEAD) ($(git log -1 --format='%s'))"


### PR DESCRIPTION
The first real prod deploy of the fågelbok feature ([#19](https://github.com/helit/birdlog/pull/19)) surfaced three repo bugs and one configuration gap. This PR fixes all of them.

## What was wrong

1. **`scripts/deploy.sh` was wrong for the host.** Targeted `docker-compose.prod.yml`, no `sudo`, assumed the image was built by compose. The actual host runs `docker-compose.yml`, requires `sudo` (henrik isn't in the docker group on TrueNAS SCALE), and uses `image: birdlog-app` (no build stanza).
2. **`backfill:taxonomy` npm script failed inside Docker.** `tsx --env-file=.env` hard-fails when there's no `.env` file in cwd — and there isn't one inside the container; env vars come from Docker's `env_file` directive.
3. **The host had a permanent dirty working tree.** `docker-compose.yml` had been edited by hand to point Postgres at `/mnt/Data/AppData/Birdlog/postgres-data`, which broke `git pull --ff-only`.
4. **The fågelbok rollout runbook was fiction.** Its commands didn't run on the actual host.

## Changes

| File | Change |
|---|---|
| `docker-compose.yml` | DB volume now `${POSTGRES_DATA:-birdlog-data}`. Default keeps dev's named volume; prod sets `POSTGRES_DATA=/mnt/...` in root `.env`. |
| `.env.example` | Documents `POSTGRES_DATA`. |
| `packages/server/package.json` | Drops `--env-file=.env` from `backfill:taxonomy`. Adds `dotenv` as devDep. |
| `packages/server/prisma/backfill-taxonomy.ts` | `import \"dotenv/config\"` at the top — loads `.env` locally, no-ops in container. |
| `scripts/deploy.sh` | Rewritten: default compose file, `sudo`, explicit `docker build` step, dirty-tree refusal guard. |
| `docs/runbooks/fagelbok-production-rollout.md` | Rewritten to match commands that actually worked. |

## Test plan

- [x] `npm run test --workspace=packages/server` — 9 files / 80 tests passing
- [x] `npm run typecheck` clean (client + server + shared)
- [x] `npm run lint` clean (1 pre-existing warning, unrelated)
- [x] `docker compose config` verifies `\${POSTGRES_DATA:-birdlog-data}` resolves to `birdlog-data` when unset and to a bind mount when set
- [x] `bash -n scripts/deploy.sh` syntax-clean, `--help` renders
- [ ] Host-cleanup steps below executed on TrueNAS, then a real \`./scripts/deploy.sh\` run succeeds end-to-end

## Host cleanup (do this after merging, before next deploy)

These are one-time housekeeping steps on `henrik@192.168.0.10:/var/www/birdlog`. The currently-running containers stay up throughout — none of these steps recreate them.

\`\`\`bash
ssh henrik@192.168.0.10
cd /var/www/birdlog

# 1. Pull this PR
git fetch origin && git checkout main && git pull --ff-only

# 2. Drop the now-canonical compose-file edits (they're replaced by the env var)
git checkout -- docker-compose.yml docker-compose.prod.yml

# 3. Create the host-level .env that compose reads. POSTGRES_DATA is the only required key.
cat > .env <<'ENVFILE'
POSTGRES_DATA=/mnt/Data/AppData/Birdlog/postgres-data
ENVFILE
chmod 600 .env

# 4. Tidy obsolete artifacts
rm -f debug.txt docker-compose.yml.pre-migration docker-compose.prod.yml.pre-migration .env.prod
\`\`\`

Confirm a clean working tree:
\`\`\`bash
git status   # should be: nothing to commit, working tree clean
\`\`\`

Then on the next deploy:
\`\`\`bash
./scripts/deploy.sh
\`\`\`

The recreated db container will read `POSTGRES_DATA` and bind-mount the same on-disk path as before — data is preserved.

## Out of scope

- **`docker-compose.prod.yml`** is still in the repo but unused by prod. It's a more proper config (no exposed DB port, `${DB_PASSWORD}` interpolation, etc.). Migrating prod onto it is a separate exercise — would need to reconcile env vars and the hardcoded DB password.
- **Secrets rotation** — during local verification, `docker compose config` dumped dev secrets to the agent transcript. Rotate `ARTDATABANKEN_API_KEY`, `OPENAI_API_KEY`, and `JWT_SECRET` if any are shared between dev and prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)