### PR TITLE
feat(e2e-safety-net): backfill unit tests for auth + profile pages

### DIFF
--- a/packages/client/src/pages/LoginPage.test.tsx
+++ b/packages/client/src/pages/LoginPage.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import LoginPage from "./LoginPage";
+
+vi.mock("@apollo/client", () => ({
+  useMutation: vi.fn(),
+  gql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    strings.reduce((acc, str, i) => acc + str + (values[i] ?? ""), ""),
+}));
+
+vi.mock("../graphql/mutations.js", () => ({
+  LOGIN_MUTATION: "LOGIN_MUTATION",
+}));
+
+vi.mock("../context/AuthContext.js", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("lucide-react", () => ({
+  BirdIcon: () => <svg data-testid="bird-icon" />,
+}));
+
+import { useMutation } from "@apollo/client";
+import { useAuth } from "../context/AuthContext.js";
+
+const mockUseMutation = vi.mocked(useMutation);
+const mockUseAuth = vi.mocked(useAuth);
+const mockLogin = vi.fn();
+
+const USER = { id: "1", email: "anna@exempel.se", name: "Anna" };
+
+function mockMutation(result: object, mutationFn = vi.fn()) {
+  mockUseMutation.mockReturnValue([
+    mutationFn,
+    result,
+  ] as unknown as ReturnType<typeof useMutation>);
+  return mutationFn;
+}
+
+function setup() {
+  return render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockLogin.mockReset();
+  mockUseAuth.mockReturnValue({ login: mockLogin } as unknown as ReturnType<typeof useAuth>);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LoginPage", () => {
+  it("calls login() with token and user on successful submit", async () => {
+    const user = userEvent.setup();
+    const mutationFn = mockMutation(
+      { loading: false, error: undefined },
+      vi.fn().mockResolvedValue({ data: { login: { token: "t", user: USER } } }),
+    );
+
+    setup();
+
+    await user.type(screen.getByLabelText("E-post"), "anna@exempel.se");
+    await user.type(screen.getByLabelText("Lösenord"), "hemligt");
+    await user.click(screen.getByRole("button", { name: "Logga in" }));
+
+    expect(mutationFn).toHaveBeenCalledWith({
+      variables: { email: "anna@exempel.se", password: "hemligt" },
+    });
+    await waitFor(() => expect(mockLogin).toHaveBeenCalledWith("t", USER));
+  });
+
+  it("renders the mutation error message", () => {
+    mockMutation({ loading: false, error: { message: "Fel uppgifter" } });
+
+    setup();
+
+    expect(screen.getByText("Fel uppgifter")).toBeInTheDocument();
+  });
+
+  it("disables the submit button and shows 'Loggar in...' while loading", () => {
+    mockMutation({ loading: true, error: undefined });
+
+    setup();
+
+    const btn = screen.getByRole("button", { name: "Loggar in..." });
+    expect(btn).toBeDisabled();
+  });
+});

--- a/packages/client/src/pages/ProfilePage.test.tsx
+++ b/packages/client/src/pages/ProfilePage.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProfilePage from "./ProfilePage";
+
+vi.mock("@apollo/client", () => ({
+  useQuery: vi.fn(),
+  gql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    strings.reduce((acc, str, i) => acc + str + (values[i] ?? ""), ""),
+}));
+
+vi.mock("@/graphql/queries", () => ({
+  MY_STATS: "MY_STATS",
+}));
+
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("lucide-react", () => ({
+  BinocularsIcon: () => <svg />,
+  BirdIcon: () => <svg />,
+  CalendarIcon: () => <svg />,
+  ChevronRightIcon: () => <svg />,
+  KeyRoundIcon: () => <svg />,
+  LogOutIcon: () => <svg />,
+  UserIcon: () => <svg />,
+}));
+
+import { useQuery } from "@apollo/client";
+import { useAuth } from "@/context/AuthContext";
+
+const mockUseQuery = vi.mocked(useQuery);
+const mockUseAuth = vi.mocked(useAuth);
+const mockLogout = vi.fn();
+
+const USER = { id: "1", email: "anna@exempel.se", name: "Anna" };
+const STATS = {
+  totalSightings: 42,
+  uniqueSpecies: 12,
+  memberSince: "2024-03-15T00:00:00.000Z",
+};
+
+function mockQuery(result: object) {
+  mockUseQuery.mockReturnValue(result as unknown as ReturnType<typeof useQuery>);
+}
+
+beforeEach(() => {
+  mockLogout.mockReset();
+  mockUseAuth.mockReturnValue({
+    user: USER,
+    logout: mockLogout,
+  } as unknown as ReturnType<typeof useAuth>);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ProfilePage", () => {
+  it("renders user name/email and stats from MY_STATS", () => {
+    mockQuery({ data: { myStats: STATS }, error: undefined });
+
+    render(<ProfilePage />);
+
+    expect(screen.getByText("Anna")).toBeInTheDocument();
+    expect(screen.getByText("anna@exempel.se")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("Observationer")).toBeInTheDocument();
+    expect(screen.getByText(/2024/)).toBeInTheDocument();
+  });
+
+  it("shows the error fallback when the stats query errors", () => {
+    mockQuery({ data: undefined, error: { message: "boom" } });
+
+    render(<ProfilePage />);
+
+    expect(screen.getByText("Kunde inte hämta statistik.")).toBeInTheDocument();
+    expect(screen.queryByText("Observationer")).not.toBeInTheDocument();
+  });
+
+  it("renders name/email but no stats grid when there are no stats", () => {
+    mockQuery({ data: undefined, error: undefined });
+
+    render(<ProfilePage />);
+
+    expect(screen.getByText("Anna")).toBeInTheDocument();
+    expect(screen.getByText("anna@exempel.se")).toBeInTheDocument();
+    expect(screen.queryByText("Observationer")).not.toBeInTheDocument();
+  });
+
+  it("calls logout when the logout button is clicked", async () => {
+    const user = userEvent.setup();
+    mockQuery({ data: { myStats: STATS }, error: undefined });
+
+    render(<ProfilePage />);
+
+    await user.click(screen.getByRole("button", { name: /Logga ut/ }));
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/client/src/pages/RegisterPage.test.tsx
+++ b/packages/client/src/pages/RegisterPage.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import RegisterPage from "./RegisterPage";
+
+vi.mock("@apollo/client", () => ({
+  useMutation: vi.fn(),
+  gql: (strings: TemplateStringsArray, ...values: unknown[]) =>
+    strings.reduce((acc, str, i) => acc + str + (values[i] ?? ""), ""),
+}));
+
+vi.mock("../graphql/mutations.js", () => ({
+  REGISTER_MUTATION: "REGISTER_MUTATION",
+}));
+
+vi.mock("../context/AuthContext.js", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("lucide-react", () => ({
+  BirdIcon: () => <svg data-testid="bird-icon" />,
+}));
+
+import { useMutation } from "@apollo/client";
+import { useAuth } from "../context/AuthContext.js";
+
+const mockUseMutation = vi.mocked(useMutation);
+const mockUseAuth = vi.mocked(useAuth);
+const mockLogin = vi.fn();
+
+const USER = { id: "1", email: "ny@exempel.se", name: "Ny Användare" };
+
+function mockMutation(result: object, mutationFn = vi.fn()) {
+  mockUseMutation.mockReturnValue([
+    mutationFn,
+    result,
+  ] as unknown as ReturnType<typeof useMutation>);
+  return mutationFn;
+}
+
+function setup() {
+  return render(
+    <MemoryRouter>
+      <RegisterPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockLogin.mockReset();
+  mockUseAuth.mockReturnValue({ login: mockLogin } as unknown as ReturnType<typeof useAuth>);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("RegisterPage", () => {
+  it("calls login() with token and user after successful registration", async () => {
+    const user = userEvent.setup();
+    const mutationFn = mockMutation(
+      { loading: false, error: undefined },
+      vi.fn().mockResolvedValue({ data: { register: { token: "t", user: USER } } }),
+    );
+
+    setup();
+
+    await user.type(screen.getByLabelText("Namn"), "Ny Användare");
+    await user.type(screen.getByLabelText("E-post"), "ny@exempel.se");
+    await user.type(screen.getByLabelText("Lösenord"), "hemligt");
+    await user.click(screen.getByRole("button", { name: "Registrera" }));
+
+    expect(mutationFn).toHaveBeenCalledWith({
+      variables: { name: "Ny Användare", email: "ny@exempel.se", password: "hemligt" },
+    });
+    await waitFor(() => expect(mockLogin).toHaveBeenCalledWith("t", USER));
+  });
+
+  it("renders the mutation error message", () => {
+    mockMutation({ loading: false, error: { message: "E-post upptagen" } });
+
+    setup();
+
+    expect(screen.getByText("E-post upptagen")).toBeInTheDocument();
+  });
+
+  it("disables the submit button and shows 'Registrerar...' while loading", () => {
+    mockMutation({ loading: true, error: undefined });
+
+    setup();
+
+    const btn = screen.getByRole("button", { name: "Registrerar..." });
+    expect(btn).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

Backfill Vitest unit tests for the auth + profile surfaces (LoginPage, RegisterPage, ProfilePage). Test-only change — no production code touched. Closes the unit-coverage half of the E2E safety-net epic.

- `LoginPage.test.tsx` — golden submit (`login()` called via `waitFor`), mutation error render, loading-disabled (`"Loggar in..."`)
- `RegisterPage.test.tsx` — golden submit with register payload, error render, loading-disabled (`"Registrerar..."`)
- `ProfilePage.test.tsx` — golden render (name/email + stats), error fallback, empty-stats (grid absent, name/email still render), logout button calls `logout`

## Plan

See the Plan TL;DR on the task issue: https://github.com/helit/birdlog/issues/29#issuecomment-4553141134

## Epic

Part of #24 — Establish an E2E safety net for all core flows

## Test Plan

- [x] All unit tests pass (`npm run test --workspace=packages/client` — 81/81, 15 files)
- [x] Linter clean (`npm run lint` — 0 errors)
- [x] Each page asserts golden path + ≥1 error/empty state (per epic #24 acceptance)
- [x] Mock specifiers match each importer (`.js`-relative for Login/Register, `@/` for Profile)

## Review

Complexity: 0 criteria met (test-only; no auth/security production code, no schema, no new deps, no API change, 3 files, no concurrency)
Reviewers: tech-lead
Critical findings: 0 found
Minor findings: 3 (advisory — untested falsy-data guard, unused bird-icon testid, bare-number `getByText`)

Closes #29
Part of #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)