### PR TITLE
feat(e2e-safety-net): add E2E spec for auth flows (register + login)

### DIFF
--- a/packages/client/e2e/auth.spec.ts
+++ b/packages/client/e2e/auth.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+// Specs visit /login and /register, so they must run logged out. The global
+// config authenticates via storageState; override it to an empty state here,
+// otherwise an authed session redirects /login and /register to / (App.tsx).
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const SEEDED_EMAIL = process.env.E2E_EMAIL ?? 'test@birdlog.test';
+const SEEDED_PASSWORD = process.env.E2E_PASSWORD ?? 'test-password';
+
+test.describe('Auth flows', () => {
+  test('logs in with seeded credentials and lands on the home page', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('E-post').fill(SEEDED_EMAIL);
+    await page.getByLabel('Lösenord').fill(SEEDED_PASSWORD);
+    await page.getByRole('button', { name: 'Logga in' }).click();
+
+    await expect(page).toHaveURL('/');
+    await expect(page.getByRole('tab', { name: 'Identifiera' })).toBeVisible();
+  });
+
+  test('keeps the user on /login and shows an error with invalid credentials', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('E-post').fill(SEEDED_EMAIL);
+    await page.getByLabel('Lösenord').fill('definitely-wrong-password');
+    await page.getByRole('button', { name: 'Logga in' }).click();
+
+    await expect(page.locator('p.text-destructive')).toBeVisible();
+    await expect(page).toHaveURL('/login');
+  });
+
+  test('registers a new user with a unique email and lands on the home page', async ({ page }) => {
+    await page.goto('/register');
+    await page.getByLabel('Namn').fill('E2E Test');
+    await page.getByLabel('E-post').fill(`e2e-${Date.now()}@birdlog.test`);
+    await page.getByLabel('Lösenord').fill('test-password');
+    await page.getByRole('button', { name: 'Registrera' }).click();
+
+    await expect(page).toHaveURL('/');
+    await expect(page.getByRole('tab', { name: 'Identifiera' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `packages/client/e2e/auth.spec.ts` covering the auth golden paths + a login error state. Test-only — no production code touched.

- Login golden path: fill seeded credentials → assert URL `/` + authed nav tab.
- Login error state: wrong password → assert destructive error visible + still on `/login`.
- Register golden path: unique `e2e-${Date.now()}@…` email → assert URL `/` + authed nav tab.
- Top-of-file `test.use({ storageState: { cookies: [], origins: [] } })` override so specs run logged out (global config authenticates via `storageState`).

## Plan

See the Plan TL;DR on the task issue: https://github.com/helit/birdlog/issues/32#issuecomment-4554627613

## Epic

Part of #24 — Establish an E2E safety net for all core flows

## Test Plan

- [x] Client unit tests pass — 81/0 (`npm run test --workspace=packages/client`)
- [x] Server unit tests pass — 80/0 (`npm run test --workspace=packages/server`)
- [x] Lint clean — 0 errors (1 pre-existing warning at `SightingFormPage.tsx:76`, unrelated to this branch) (`npm run lint`)
- [x] Auth E2E green against real backend — 7/0 (`npx playwright test auth.spec.ts`, Phase 4)
- [ ] Reviewer sanity-check: log in with seeded `test@birdlog.test` / wrong-password / unique register email all behave as asserted

## Review

Complexity: 0/6 criteria met (test-only, single file, 42 LOC)
Reviewers: tech-lead
Critical findings: 0
Major findings: 1 (advisory — `p.text-destructive` selector couples to Tailwind class; clean fix requires adding `role="alert"` to production `LoginPage`/`RegisterPage` — out of scope for this test-only task, file a follow-up)
Minor findings: 2 (noted)

Closes #32
Part of #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)